### PR TITLE
fix(docker): remove deprecated statement; use recommended syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   vnc:
     build:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest as pyra2yr
+FROM ubuntu:latest AS pyra2yr
 
 RUN dpkg --add-architecture i386
 

--- a/docker/vnc.Dockerfile
+++ b/docker/vnc.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest as src
+FROM alpine:latest AS src
 RUN apk add --no-cache \
 	bash \
 	git \


### PR DESCRIPTION
- "the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
- "WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match"