### PR TITLE
fix: create symlink for latest CnCNet YR files

### DIFF
--- a/scripts/run-gamemd.py
+++ b/scripts/run-gamemd.py
@@ -56,6 +56,9 @@ cncnet5.dll
 CnCNet-Spawner.dll
 cncnet.mix
 gamemd.exe
+Phobos.dll
+Ares.dll
+ares.mix
 {NAME_SPAWNER}\
 """
 

--- a/scripts/run-gamemd.py
+++ b/scripts/run-gamemd.py
@@ -54,6 +54,7 @@ Syringe.exe
 cncnet.fnt
 cncnet5.dll
 CnCNet-Spawner.dll
+cncnet.mix
 gamemd.exe
 {NAME_SPAWNER}\
 """

--- a/scripts/run-gamemd.py
+++ b/scripts/run-gamemd.py
@@ -53,6 +53,7 @@ ddraw.dll
 Syringe.exe
 cncnet.fnt
 cncnet5.dll
+CnCNet-Spawner.dll
 gamemd.exe
 {NAME_SPAWNER}\
 """


### PR DESCRIPTION
For compatibility, didn't remove "cncnet5.dll".

I think we will append "Ares.dll" and "Phobos.dll" at some point in the future when we are ready to use all features and bug fixes from the project "CnCNet/cncnet-yr-client-package".