### PR TITLE
feat: disable auto-save to avoid lagging

### DIFF
--- a/pyra2yr/game.py
+++ b/pyra2yr/game.py
@@ -303,6 +303,7 @@ class MultiGameInstanceConfig:
             ("MultiEngineer", S.multi_engineer),
             ("BridgeDestory", S.bridges_destroyable),
             ("BuildOffAlly", S.build_off_ally),
+            ("AutoSaveInterval", 0),
         ]
 
         main_section_values.extend(self.player_values(player))


### PR DESCRIPTION
A quick editing.

Some "GameClient::Manager.get_state()" calls seem to be ignored in single step mode during auto-save.

- https://github.com/CnCNet/cncnet-yr-client-package/blob/ae7f2893e3ec5542135a72d56f85ce79c206b325/package/Resources/CampaignSelector.ini#L56-L66
- https://github.com/CnCNet/yrpp-spawner/blob/fed3e8b276728afebaea2a1dc1f6a4d59ca444e8/src/Spawner/Spawner.Config.h#L176